### PR TITLE
[codex] Add checkout readiness errors and order history

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+allowBuilds:
+  '@swc/core': set this to true or false
+  esbuild: set this to true or false
+  msw: set this to true or false
+  sharp: set this to true or false
+  workerd: set this to true or false
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild

--- a/src/context/CartContext.test.tsx
+++ b/src/context/CartContext.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CartProvider, useCart } from "./CartContext";
+
+vi.mock("../config", () => ({
+  BASE_URL: "http://test.local",
+}));
+
+class MockBroadcastChannel {
+  addEventListener() {}
+  removeEventListener() {}
+  postMessage() {}
+  close() {}
+}
+
+function TestHarness() {
+  const { addToCart, cart } = useCart();
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          addToCart({
+            id: 1,
+            name: "RC Wheels",
+            price: 35,
+            quantity: 1,
+            color: "#ffffff",
+            filamentType: "PLA",
+            filamentId: "",
+            skuNumber: "SKU-123",
+          })
+        }>
+        Add
+      </button>
+      <span data-testid="count">{cart.length}</span>
+    </div>
+  );
+}
+
+describe("CartContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("does not call remote cart APIs when filamentId is missing", async () => {
+    const user = userEvent.setup();
+    render(
+      <CartProvider>
+        <TestHarness />
+      </CartProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(console.error).toHaveBeenCalledWith(
+      "filamentId missing – cannot add to cart remotely",
+    );
+  });
+});

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -176,6 +176,10 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
         console.error("skuNumber missing – cannot add to cart remotely");
         return;
       }
+      if (!item.filamentId) {
+        console.error("filamentId missing – cannot add to cart remotely");
+        return;
+      }
       const cartId = await ensureCartId();
 
       const previous = optimisticAdd(item);

--- a/src/context/CartContext.tsx
+++ b/src/context/CartContext.tsx
@@ -146,6 +146,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
     quantity: number;
     color: string;
     filamentType: string;
+    filamentId: string;
   }) => {
     const res = await fetch(`${BASE_URL}/cart/add`, {
       method: "POST",
@@ -188,6 +189,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
           quantity: item.quantity,
           color: colorValue,
           filamentType: item.filamentType,
+          filamentId: item.filamentId,
         });
       } catch (err) {
         console.error(err);

--- a/src/interfaces/cartItem.ts
+++ b/src/interfaces/cartItem.ts
@@ -23,6 +23,7 @@ export type CartItem = {
   quantity: number;
   color: string;
   filamentType: string;
+  filamentId: string;
   skuNumber: string; // Needed for remote cart API operations
   // Optionally add more fields as needed
 };

--- a/src/pages/Checkout.test.tsx
+++ b/src/pages/Checkout.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Checkout from "./Checkout";
+
+vi.mock("../config", () => ({
+  BASE_URL: "http://test.local",
+}));
+
+const updateQuantity = vi.fn();
+
+vi.mock("../context/CartContext", () => ({
+  useCart: () => ({
+    updateQuantity,
+  }),
+}));
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function renderCheckout() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/checkout",
+        element: <Checkout />,
+      },
+    ],
+    {
+      initialEntries: ["/checkout"],
+      future: { v7_relativeSplatPath: true },
+    },
+  );
+
+  render(<RouterProvider router={router} />);
+}
+
+describe("Checkout", () => {
+  beforeEach(() => {
+    localStorage.setItem("cartId", "cart-1");
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === "http://test.local/profile") {
+        return jsonResponse({
+          email: "customer@example.com",
+          firstName: "Casey",
+          lastName: "Customer",
+          address: "123 Test St",
+          city: "Phoenix",
+          state: "AZ",
+          zipCode: "85001",
+          country: "US",
+          phone: "555-555-5555",
+        });
+      }
+
+      if (url === "http://test.local/cart/cart-1") {
+        return jsonResponse({
+          items: [
+            {
+              id: 7,
+              name: "RC Wheel",
+              skuNumber: "WHEEL-1",
+              productId: "WHEEL-1",
+              quantity: 1,
+              color: "ff0000",
+              filamentType: "PLA",
+              filamentId: "00000000-0000-4000-8000-000000000000",
+              stripePriceId: "price_123",
+              price: 12,
+            },
+          ],
+          total: 12,
+        });
+      }
+
+      if (url === "http://test.local/cart/cart-1/stripe-items") {
+        return jsonResponse({
+          line_items: [{ price: "price_123", quantity: 1 }],
+        });
+      }
+
+      if (url === "http://test.local/cart/cart-1/payment-intent") {
+        return jsonResponse(
+          {
+            error: "Cart is not ready for checkout",
+            items: [
+              {
+                cartItemId: 7,
+                skuNumber: "WHEEL-1",
+                reasons: [
+                  "missing_public_file_service_id",
+                  "unavailable_filament_id",
+                ],
+              },
+            ],
+          },
+          { status: 409 },
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+    updateQuantity.mockReset();
+  });
+
+  it("shows cart readiness failures next to checkout actions", async () => {
+    const user = userEvent.setup();
+
+    renderCheckout();
+
+    await screen.findByText("RC Wheel");
+    await user.click(screen.getByRole("button", { name: /confirm order/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Cart is not ready for checkout");
+    expect(alert).toHaveTextContent("RC Wheel");
+    expect(alert).toHaveTextContent("missing printable file");
+    expect(alert).toHaveTextContent("selected filament is unavailable");
+  });
+});

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -13,6 +13,7 @@ interface CartApiItem {
   quantity: number;
   color: string;
   filamentType: string;
+  filamentId: string;
   stripePriceId: string | null;
   price: number;
 }
@@ -53,8 +54,93 @@ interface PaymentIntentResponse {
   orderId?: string | number;
 }
 
+interface CheckoutReadinessErrorItem {
+  cartItemId: number;
+  skuNumber: string | null;
+  reasons: string[];
+}
+
+interface CheckoutReadinessErrorResponse {
+  error: string;
+  items: CheckoutReadinessErrorItem[];
+}
+
+const readinessReasonLabels: Record<string, string> = {
+  product_missing: "product is no longer available",
+  missing_stripe_price_id: "missing checkout price",
+  missing_public_file_service_id: "missing printable file",
+  invalid_quantity: "invalid quantity",
+  invalid_filament_id: "invalid filament selection",
+  unavailable_filament_id: "selected filament is unavailable",
+};
+
 function isObject(val: unknown): val is Record<string, unknown> {
   return typeof val === "object" && val !== null;
+}
+
+function isCheckoutReadinessError(
+  obj: unknown,
+): obj is CheckoutReadinessErrorResponse {
+  if (!isObject(obj) || typeof obj.error !== "string") return false;
+
+  return (
+    Array.isArray(obj.items) &&
+    obj.items.every(
+      (item) =>
+        isObject(item) &&
+        typeof item.cartItemId === "number" &&
+        (typeof item.skuNumber === "string" || item.skuNumber === null) &&
+        Array.isArray(item.reasons) &&
+        item.reasons.every((reason) => typeof reason === "string"),
+    )
+  );
+}
+
+function formatReadinessError(
+  response: CheckoutReadinessErrorResponse,
+  cartItems: CartApiItem[],
+) {
+  const itemMessages = response.items.map((item) => {
+    const cartItem = cartItems.find(
+      (candidate) =>
+        candidate.id === item.cartItemId ||
+        candidate.skuNumber === item.skuNumber,
+    );
+    const itemName =
+      cartItem?.name ?? item.skuNumber ?? `Cart item ${item.cartItemId}`;
+    const reasons = item.reasons
+      .map((reason) => readinessReasonLabels[reason] ?? reason)
+      .join(", ");
+
+    return `${itemName}: ${reasons}`;
+  });
+
+  return `${response.error}. ${itemMessages.join("; ")}`;
+}
+
+async function paymentErrorMessage(res: Response, cartItems: CartApiItem[]) {
+  const text = await res.text();
+  let parsed: unknown = null;
+
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = null;
+    }
+  }
+
+  if (isCheckoutReadinessError(parsed)) {
+    return formatReadinessError(parsed, cartItems);
+  }
+
+  if (isObject(parsed) && typeof parsed.error === "string") {
+    const details =
+      typeof parsed.details === "string" ? `: ${parsed.details}` : "";
+    return `${parsed.error}${details}`;
+  }
+
+  return `Payment intent request failed (${res.status})${text ? `: ${text}` : ""}`;
 }
 
 function parsePaymentIntentResponse(
@@ -102,6 +188,7 @@ export default function Checkout() {
   const [stripeItems, setStripeItems] = useState<StripeLineItem[]>([]);
   const [cartLoading, setCartLoading] = useState(true);
   const [cartError, setCartError] = useState<string | null>(null);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
   const [updatingIdx, setUpdatingIdx] = useState<number | null>(null);
   const [shippingCost, setShippingCost] = useState<number>(0);
   const [shippingError, setShippingError] = useState<string | null>(null);
@@ -154,6 +241,7 @@ export default function Checkout() {
   const fetchRemoteCart = async () => {
     setCartLoading(true);
     setCartError(null);
+    setCheckoutError(null);
     try {
       const cartId = localStorage.getItem("cartId");
       if (!cartId) throw new Error("No cartId found");
@@ -226,7 +314,7 @@ export default function Checkout() {
       return;
     }
     setCartLoading(true);
-    setCartError(null);
+    setCheckoutError(null);
     try {
       const res = await fetch(`${BASE_URL}/cart/${cartId}/payment-intent`, {
         method: "POST",
@@ -235,10 +323,7 @@ export default function Checkout() {
         body: JSON.stringify({ shippingInfo, profile }),
       });
       if (!res.ok) {
-        const text = await res.text();
-        throw new Error(
-          `Payment intent request failed (${res.status}): ${text}`,
-        );
+        throw new Error(await paymentErrorMessage(res, remoteCart));
       }
       const dataJson: unknown = await res.json();
       const data = parsePaymentIntentResponse(dataJson);
@@ -262,7 +347,7 @@ export default function Checkout() {
         navigate(`/order/${data.orderId}`);
       }
     } catch (err: unknown) {
-      setCartError(
+      setCheckoutError(
         err instanceof Error ? err.message : "Payment intent failed",
       );
     } finally {
@@ -472,6 +557,13 @@ export default function Checkout() {
                 );
               })()}
               <div className="border-t border-gray-200 px-4 py-6 sm:px-6">
+                {checkoutError && (
+                  <div
+                    role="alert"
+                    className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                    {checkoutError}
+                  </div>
+                )}
                 <button
                   type="submit"
                   className="w-full rounded-md border border-transparent bg-indigo-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:ring-offset-gray-50">

--- a/src/pages/Product.tsx
+++ b/src/pages/Product.tsx
@@ -180,7 +180,14 @@ export default function ProductPage() {
 
               <button
                 type="button"
-                onClick={() =>
+                onClick={() => {
+                  const selectedColor = state.colorOptions.find(
+                    (colorOption) => colorOption.hexValue === state.color,
+                  );
+                  if (!selectedColor) {
+                    console.error("filamentId missing for selected color");
+                    return;
+                  }
                   addToCart({
                     id: Number(id),
                     name: product.name,
@@ -188,10 +195,11 @@ export default function ProductPage() {
                     color: state.color,
                     quantity,
                     filamentType: selectedFilament,
+                    filamentId: selectedColor.publicId,
                     image: product.image,
                     skuNumber: product.skuNumber,
-                  })
-                }
+                  });
+                }}
                 className="mt-8 flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-8 py-3 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                 Add to cart
               </button>

--- a/src/pages/Profile.test.tsx
+++ b/src/pages/Profile.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Profile from "./Profile";
+
+vi.mock("../config", () => ({
+  BASE_URL: "http://test.local",
+}));
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+const profileResponse = {
+  id: 1,
+  email: "customer@example.com",
+  firstName: "Casey",
+  lastName: "Customer",
+  address: "123 Test St",
+  city: "Phoenix",
+  state: "AZ",
+  zipCode: "85001",
+  country: "US",
+  phone: "555-555-5555",
+};
+
+function mockProfileFetch(ordersHandler: () => Promise<Response>) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+
+    if (url === "http://test.local/profile") {
+      return jsonResponse(profileResponse);
+    }
+
+    if (url === "http://test.local/api/auth/passkey/list-user-passkeys") {
+      return jsonResponse([]);
+    }
+
+    if (url === "http://test.local/orders?limit=10") {
+      return ordersHandler();
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Profile orders", () => {
+  it("shows loading state while orders are being fetched", async () => {
+    mockProfileFetch(() => new Promise<Response>(() => {}));
+
+    render(<Profile />);
+
+    expect(await screen.findByText("Loading orders...")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no orders are returned", async () => {
+    mockProfileFetch(async () => jsonResponse({ orders: [] }));
+
+    render(<Profile />);
+
+    expect(await screen.findByText("No orders yet.")).toBeInTheDocument();
+  });
+
+  it("shows an error state when orders fetch fails", async () => {
+    mockProfileFetch(async () => jsonResponse({}, { status: 500 }));
+
+    render(<Profile />);
+
+    expect(await screen.findByText("Failed to fetch orders")).toBeInTheDocument();
+  });
+
+  it("renders an order with status, total, and tracking link", async () => {
+    mockProfileFetch(async () =>
+      jsonResponse({
+        orders: [
+          {
+            id: 101,
+            orderNumber: "ORD-101",
+            createdAt: "2026-01-03T00:00:00.000Z",
+            status: null,
+            slantStatus: "Shipped",
+            totalAmountCents: 2599,
+            currency: "usd",
+            items: [
+              {
+                skuNumber: "WHEEL-1",
+                name: "RC Wheel",
+                quantity: 1,
+                color: "Red",
+                filamentType: "PLA",
+                image: null,
+                price: 25.99,
+              },
+            ],
+            fulfillment: {
+              trackingNumber: "TRACK123",
+              trackingUrl: "https://carrier.example/track/123",
+              carrier: "USPS",
+              shippedAt: "2026-01-04T00:00:00.000Z",
+              deliveredAt: null,
+            },
+            cancellation: null,
+          },
+        ],
+      }),
+    );
+
+    render(<Profile />);
+
+    const expectedTotal = new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: "USD",
+    }).format(25.99);
+
+    expect(await screen.findByText("ORD-101")).toBeInTheDocument();
+    expect(screen.getByText("Shipped")).toBeInTheDocument();
+    expect(screen.getByText(expectedTotal)).toBeInTheDocument();
+
+    const trackingLink = screen.getByRole("link", { name: "Track shipment" });
+    expect(trackingLink).toHaveAttribute(
+      "href",
+      "https://carrier.example/track/123",
+    );
+  });
+});

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -509,7 +509,9 @@ const Profile = () => {
           </h3>
         </div>
         {ordersError && (
-          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 border border-red-200">
+          <div
+            role="alert"
+            className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 border border-red-200">
             {ordersError}
           </div>
         )}
@@ -639,7 +641,7 @@ const Profile = () => {
               <li
                 key={passkeyId || credentialId || `passkey-${index}`}
                 className="flex items-center justify-between rounded border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-800">
-                <span className="font-mono text-xs text-white dark:text-gray-300">
+                <span className="font-mono text-xs text-gray-900 dark:text-gray-300">
                   {credentialId || "Unknown passkey"}
                 </span>
                 <button

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -29,6 +29,39 @@ interface ProfileUpdateErrorResponse {
   details?: ProfileUpdateErrorDetail[];
 }
 
+interface CustomerOrderItem {
+  skuNumber: string | null;
+  name: string | null;
+  quantity: number;
+  color: string | null;
+  filamentType: string | null;
+  image: string | null;
+  price: number | null;
+}
+
+interface CustomerOrder {
+  id: number;
+  orderNumber: string;
+  createdAt: string | null;
+  status: string | null;
+  slantStatus: string | null;
+  totalAmountCents: number | null;
+  currency: string | null;
+  items: CustomerOrderItem[];
+  fulfillment: {
+    trackingNumber: string | null;
+    trackingUrl: string | null;
+    carrier: string | null;
+    shippedAt: string | null;
+    deliveredAt: string | null;
+  };
+  cancellation: { canceledAt: string | null } | null;
+}
+
+interface CustomerOrdersResponse {
+  orders: CustomerOrder[];
+}
+
 // Small internal display component for read-only profile fields
 const Info = ({
   label,
@@ -51,11 +84,38 @@ const Info = ({
   </div>
 );
 
+function formatDate(value: string | null) {
+  if (!value) return "Pending";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatMoney(cents: number | null, currency: string | null) {
+  if (typeof cents !== "number") return "Pending";
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: (currency || "usd").toUpperCase(),
+  }).format(cents / 100);
+}
+
+function orderStatus(order: CustomerOrder) {
+  if (order.cancellation?.canceledAt) return "Canceled";
+  return order.slantStatus || order.status || "Processing";
+}
+
 const Profile = () => {
   const [profile, setProfile] = useState<Profile | undefined>(undefined);
   const [authenticators, setAuthenticators] = useState<PasskeyAuthenticator[]>(
     [],
   );
+  const [orders, setOrders] = useState<CustomerOrder[]>([]);
+  const [ordersLoading, setOrdersLoading] = useState(false);
+  const [ordersError, setOrdersError] = useState("");
   const [message, setMessage] = useState<string>(""); // kept for passkey flows
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -73,6 +133,25 @@ const Profile = () => {
       setForm(data);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to load profile");
+    }
+  };
+
+  const getOrders = async () => {
+    setOrdersLoading(true);
+    setOrdersError("");
+    try {
+      const res = await fetch(`${BASE_URL}/orders?limit=10`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Failed to fetch orders");
+      const data = (await res.json()) as CustomerOrdersResponse;
+      setOrders(data.orders || []);
+    } catch (err: unknown) {
+      setOrdersError(
+        err instanceof Error ? err.message : "Failed to load orders",
+      );
+    } finally {
+      setOrdersLoading(false);
     }
   };
 
@@ -214,6 +293,7 @@ const Profile = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: TODO: useEventEffect in 19
   useEffect(() => {
     getProfile();
+    getOrders();
     getAuthenticators();
   }, []);
 
@@ -425,6 +505,116 @@ const Profile = () => {
       <div className="mt-10">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+            Orders
+          </h3>
+        </div>
+        {ordersError && (
+          <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700 border border-red-200">
+            {ordersError}
+          </div>
+        )}
+        {ordersLoading && (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Loading orders...
+          </p>
+        )}
+        {!ordersLoading && orders.length === 0 && !ordersError && (
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            No orders yet.
+          </p>
+        )}
+        <div className="space-y-3">
+          {orders.map((order) => {
+            const primaryItem = order.items[0];
+            const extraItemCount = Math.max(order.items.length - 1, 0);
+
+            return (
+              <div
+                key={order.id}
+                className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-4 shadow-sm">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium text-gray-900 dark:text-gray-100">
+                        {order.orderNumber}
+                      </span>
+                      <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200">
+                        {orderStatus(order)}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                      {formatDate(order.createdAt)}
+                    </p>
+                  </div>
+                  <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {formatMoney(order.totalAmountCents, order.currency)}
+                  </div>
+                </div>
+
+                {primaryItem && (
+                  <div className="mt-4 flex gap-3">
+                    {primaryItem.image && (
+                      <img
+                        src={primaryItem.image}
+                        alt={
+                          primaryItem.name ||
+                          primaryItem.skuNumber ||
+                          "Order item"
+                        }
+                        className="h-14 w-14 rounded-md object-cover border border-gray-200 dark:border-gray-700"
+                      />
+                    )}
+                    <div className="min-w-0 text-sm">
+                      <p className="font-medium text-gray-900 dark:text-gray-100">
+                        {primaryItem.name ||
+                          primaryItem.skuNumber ||
+                          "Printed item"}
+                      </p>
+                      <p className="text-gray-600 dark:text-gray-400">
+                        Qty {primaryItem.quantity}
+                        {primaryItem.filamentType
+                          ? ` · ${primaryItem.filamentType}`
+                          : ""}
+                        {primaryItem.color ? ` · ${primaryItem.color}` : ""}
+                        {extraItemCount > 0 ? ` · +${extraItemCount} more` : ""}
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                {(order.fulfillment.trackingNumber ||
+                  order.fulfillment.shippedAt ||
+                  order.fulfillment.deliveredAt) && (
+                  <div className="mt-4 rounded-md bg-gray-50 dark:bg-gray-800 px-3 py-2 text-sm text-gray-700 dark:text-gray-200">
+                    {order.fulfillment.trackingUrl ? (
+                      <a
+                        href={order.fulfillment.trackingUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="font-medium text-indigo-600 hover:text-indigo-700 dark:text-indigo-300">
+                        Track shipment
+                      </a>
+                    ) : (
+                      <span className="font-medium">
+                        {order.fulfillment.trackingNumber || "Shipment updated"}
+                      </span>
+                    )}
+                    {order.fulfillment.carrier && (
+                      <span className="ml-2 text-gray-500">
+                        {order.fulfillment.carrier}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-10">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
             Passkeys
           </h3>
           <button
@@ -442,23 +632,24 @@ const Profile = () => {
         <ul className="space-y-2">
           {authenticators.map((auth, index) => {
             const passkeyId = auth.id;
-            const credentialId = auth.credentialID || auth.credentialId || auth.id;
+            const credentialId =
+              auth.credentialID || auth.credentialId || auth.id;
 
             return (
-            <li
-              key={passkeyId || credentialId || `passkey-${index}`}
-              className="flex items-center justify-between rounded border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-800">
-              <span className="font-mono text-xs text-white dark:text-gray-300">
-                {credentialId || "Unknown passkey"}
-              </span>
-              <button
-                type="button"
-                onClick={() => passkeyId && handleRemove(passkeyId)}
-                disabled={!passkeyId}
-                className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300">
-                Remove
-              </button>
-            </li>
+              <li
+                key={passkeyId || credentialId || `passkey-${index}`}
+                className="flex items-center justify-between rounded border border-gray-200 dark:border-gray-700 px-3 py-2 text-sm bg-white dark:bg-gray-800">
+                <span className="font-mono text-xs text-white dark:text-gray-300">
+                  {credentialId || "Unknown passkey"}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => passkeyId && handleRemove(passkeyId)}
+                  disabled={!passkeyId}
+                  className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300">
+                  Remove
+                </button>
+              </li>
             );
           })}
         </ul>


### PR DESCRIPTION
## Summary
- Send the required `filamentId` when adding products to the cart by resolving the selected color's `publicId`.
- Surface structured checkout readiness failures next to the confirm order action with readable item-level reasons.
- Add profile order history loading and rendering, including order status, totals, item summary, and tracking details.

## Why
The backend cart and checkout flow now depends on a complete filament selection and can return readiness errors when cart items are not valid for checkout. This makes the store send the required cart contract and gives customers actionable checkout feedback instead of a generic payment-intent failure.

## Validation
- `pnpm test`
- `pnpm lint`
