### PR TITLE
Add category filtering to catalog

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# Storefront
+
+The customer-facing commerce context for browsing printable products, checking out, and managing post-purchase self-service.
+
+## Language
+
+**Storefront**:
+The customer-facing shopping experience for product discovery, cart, checkout, account management, and order self-service.
+_Avoid_: Admin console, catalog management UI, back office
+
+**Customer**:
+A person who uses the storefront to buy printed products and manage their own account or orders.
+_Avoid_: Buyer, admin, operator
+
+**Order History**:
+The customer's list of previously placed orders, shown with buyer-safe order, item, payment, and fulfillment status.
+_Avoid_: Admin orders, fulfillment queue
+
+**Order Detail**:
+A read-only customer view of one order's items, totals, lifecycle status, and fulfillment information.
+_Avoid_: Cancellation workflow, refund workflow, admin order operations
+
+**Category Filter**:
+A URL-addressable, single-select product discovery control that narrows or browses the storefront catalog by category across the full catalog, not only the currently visible page. Category names come from the category list exposed by the API.
+_Avoid_: Category management, admin taxonomy
+
+**Uncategorized Product**:
+A temporary catalog state for a product without a category assignment; it may appear in the all-products view but should not become a customer-facing category.
+_Avoid_: Uncategorized category
+
+**Account Profile**:
+The customer's identity, contact, shipping, and security settings.
+_Avoid_: Order history, admin profile
+
+**Account Security**:
+The customer's authentication and credential management area, including passkeys.
+_Avoid_: Profile details, order history
+
+**Protected Customer Area**:
+A storefront area available only to signed-in customers, where sign-in should preserve the customer's intended destination.
+_Avoid_: Public catalog, admin area

--- a/docs/adr/0001-keep-storefront-customer-facing.md
+++ b/docs/adr/0001-keep-storefront-customer-facing.md
@@ -1,0 +1,3 @@
+# Keep the storefront customer-facing
+
+The store app will stay focused on customer-facing commerce: product discovery, cart, checkout, account, and order self-service. Admin catalog and order-operation views will remain outside this app, even though the shared API exposes admin endpoints, because mixing those workflows would blur permissions, navigation, and user intent.

--- a/docs/adr/0002-client-side-category-filtering-first.md
+++ b/docs/adr/0002-client-side-category-filtering-first.md
@@ -1,0 +1,5 @@
+# Start category filtering client-side
+
+The first storefront category filter will fetch the current small product catalog with a high page limit, keep the selected category in the URL, and filter/paginate the loaded products client-side. This avoids adding backend filtering before the catalog needs it, while preserving a UI shape that can later call an API-backed `categoryId` filter if the catalog grows.
+
+If loading categories fails, the product catalog should still render with the default all-products view and report the category failure as a non-blocking toast.

--- a/src/interfaces/category.ts
+++ b/src/interfaces/category.ts
@@ -1,0 +1,4 @@
+export interface CategoryResponse {
+  categoryId: number;
+  categoryName: string;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from "./category";
 export * from "./colors";
 export * from "./productResponse";
 export * from "./searchResponse";

--- a/src/interfaces/productResponse.ts
+++ b/src/interfaces/productResponse.ts
@@ -10,6 +10,7 @@ export interface ProductResponse {
   filamentType: string;
   skuNumber: string;
   color: string;
+  categoryId?: number | null;
   size?: string;
   version?: string;
 }

--- a/src/pages/ProductList.test.tsx
+++ b/src/pages/ProductList.test.tsx
@@ -1,0 +1,243 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  createMemoryRouter,
+  RouterProvider,
+  useLocation,
+} from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ProductList from "./ProductList";
+
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    error: toastError,
+  },
+}));
+
+vi.mock("../config", () => ({
+  BASE_URL: "http://test.local",
+}));
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.search}</div>;
+}
+
+const products = [
+  {
+    id: 1,
+    name: "Gear Diff Holder",
+    description: "Pit gear storage",
+    image: "gear.png",
+    imageGallery: [],
+    stl: "gear.stl",
+    price: 8.58,
+    filamentType: "PETG",
+    skuNumber: "GEAR-1",
+    color: "#000000",
+    categoryId: 2,
+  },
+  {
+    id: 2,
+    name: "Shock Stand",
+    description: "Pit bench stand",
+    image: "shock.png",
+    imageGallery: [],
+    stl: "shock.stl",
+    price: 11.05,
+    filamentType: "PLA",
+    skuNumber: "SHOCK-1",
+    color: "#2779F5",
+    categoryId: 2,
+  },
+  {
+    id: 3,
+    name: "Body Clips",
+    description: "Small replacement clips",
+    image: "clips.png",
+    imageGallery: [],
+    stl: "clips.stl",
+    price: 3.5,
+    filamentType: "PLA",
+    skuNumber: "CLIP-1",
+    color: "#056DFF",
+    categoryId: 1,
+  },
+  {
+    id: 4,
+    name: "Setup Board",
+    description: "Temporary uncategorized product",
+    image: "board.png",
+    imageGallery: [],
+    stl: "board.stl",
+    price: 14.25,
+    filamentType: "PETG",
+    skuNumber: "BOARD-1",
+    color: "#FFFFFF",
+    categoryId: null,
+  },
+];
+
+const categories = [
+  { categoryId: 1, categoryName: "Accessories" },
+  { categoryId: 2, categoryName: "Pit Area" },
+];
+
+function mockSuccessfulFetches() {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+
+    if (url === "http://test.local/products?page=1&limit=100") {
+      return jsonResponse({
+        products,
+        pagination: {
+          page: 1,
+          limit: 100,
+          totalItems: products.length,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+      });
+    }
+
+    if (url === "http://test.local/categories") {
+      return jsonResponse(categories);
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+function renderProductList(initialEntry = "/") {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: (
+          <>
+            <ProductList />
+            <LocationDisplay />
+          </>
+        ),
+      },
+    ],
+    {
+      initialEntries: [initialEntry],
+      future: { v7_relativeSplatPath: true },
+    },
+  );
+
+  render(<RouterProvider router={router} />);
+}
+
+describe("ProductList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    toastError.mockReset();
+  });
+
+  it("renders category chips from the API and initializes filtering from the URL", async () => {
+    mockSuccessfulFetches();
+
+    renderProductList("/?categoryId=2");
+
+    const pitArea = await screen.findByRole("button", { name: "Pit Area" });
+    expect(pitArea).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+
+    expect(screen.getByText("Gear Diff Holder")).toBeInTheDocument();
+    expect(screen.getByText("Shock Stand")).toBeInTheDocument();
+    expect(screen.queryByText("Body Clips")).not.toBeInTheDocument();
+    expect(screen.queryByText("Setup Board")).not.toBeInTheDocument();
+    expect(screen.getByText(/showing 1-2 of 2/i)).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent("?categoryId=2");
+  });
+
+  it("clears the category URL and restores null-category products when All is selected", async () => {
+    mockSuccessfulFetches();
+    const user = userEvent.setup();
+
+    renderProductList("/?categoryId=2");
+
+    await screen.findByText("Gear Diff Holder");
+    await user.click(screen.getByRole("button", { name: "All" }));
+
+    expect(screen.getByTestId("location")).toHaveTextContent("");
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Setup Board")).toBeInTheDocument();
+    expect(screen.getByText(/showing 1-4 of 4/i)).toBeInTheDocument();
+  });
+
+  it("selects one category at a time and writes the selected category to the URL", async () => {
+    mockSuccessfulFetches();
+    const user = userEvent.setup();
+
+    renderProductList();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Accessories" }),
+    );
+
+    expect(screen.getByTestId("location")).toHaveTextContent("?categoryId=1");
+    expect(screen.getByRole("button", { name: "Accessories" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Body Clips")).toBeInTheDocument();
+    expect(screen.queryByText("Gear Diff Holder")).not.toBeInTheDocument();
+  });
+
+  it("keeps products usable and shows a toast when categories fail to load", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === "http://test.local/products?page=1&limit=100") {
+        return jsonResponse({
+          products,
+          pagination: {
+            page: 1,
+            limit: 100,
+            totalItems: products.length,
+            totalPages: 1,
+            hasNextPage: false,
+            hasPreviousPage: false,
+          },
+        });
+      }
+
+      if (url === "http://test.local/categories") {
+        return jsonResponse({ error: "failed" }, { status: 500 });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderProductList();
+
+    expect(await screen.findByText("Gear Diff Holder")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Pit Area" }),
+    ).not.toBeInTheDocument();
+    expect(toastError).toHaveBeenCalledWith(
+      "Category filters are unavailable right now.",
+    );
+  });
+});

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -1,48 +1,114 @@
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { Link, useSearchParams } from "react-router-dom";
 import { Pagination } from "../components/Pagination";
 import { BASE_URL } from "../config";
+import type { CategoryResponse } from "../interfaces/category";
 import type {
-  PaginationInfo,
   ProductListResponse,
   ProductResponse,
 } from "../interfaces/productResponse";
 
+const CATALOG_FETCH_LIMIT = 100;
+const DEFAULT_PAGE_SIZE = 5;
+
+function parseCategoryId(value: string | null) {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
 function ProductList() {
-  const [products, setProducts] = useState<ProductResponse[]>([]);
-  const [pagination, setPagination] = useState<PaginationInfo>({
-    page: 1,
-    limit: 5,
-    totalItems: 0,
-    totalPages: 0,
-    hasNextPage: false,
-    hasPreviousPage: false,
-  });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [catalog, setCatalog] = useState<ProductResponse[]>([]);
+  const [categories, setCategories] = useState<CategoryResponse[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(DEFAULT_PAGE_SIZE);
   const [loading, setLoading] = useState(false);
 
-  const getData = async (page: number = 1, limit: number = 5) => {
-    setLoading(true);
-    try {
-      const response = await fetch(
-        `${BASE_URL}/products?page=${page}&limit=${limit}`,
-      );
-      const data = (await response.json()) as ProductListResponse;
+  const selectedCategoryId = parseCategoryId(searchParams.get("categoryId"));
 
-      setProducts(data.products);
-      setPagination(data.pagination);
-    } catch (error) {
-      console.error("error", error);
+  const getData = async () => {
+    setLoading(true);
+    const fetchProducts = async () => {
+      const response = await fetch(
+        `${BASE_URL}/products?page=1&limit=${CATALOG_FETCH_LIMIT}`,
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to fetch products (${response.status})`);
+      }
+      const data = (await response.json()) as ProductListResponse;
+      return data.products;
+    };
+
+    const fetchCategories = async () => {
+      const response = await fetch(`${BASE_URL}/categories`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch categories (${response.status})`);
+      }
+      return (await response.json()) as CategoryResponse[];
+    };
+
+    try {
+      const [productResult, categoryResult] = await Promise.allSettled([
+        fetchProducts(),
+        fetchCategories(),
+      ]);
+
+      if (productResult.status === "fulfilled") {
+        setCatalog(productResult.value);
+      } else {
+        console.error("error", productResult.reason);
+        setCatalog([]);
+      }
+
+      if (categoryResult.status === "fulfilled") {
+        setCategories(categoryResult.value);
+      } else {
+        console.error("error", categoryResult.reason);
+        toast.error("Category filters are unavailable right now.");
+        setCategories([]);
+      }
     } finally {
       setLoading(false);
     }
   };
 
-  const handlePageChange = (page: number) => {
-    getData(page, pagination.limit);
+  const filteredProducts = useMemo(() => {
+    if (selectedCategoryId === null) return catalog;
+    return catalog.filter(
+      (product) => product.categoryId === selectedCategoryId,
+    );
+  }, [catalog, selectedCategoryId]);
+
+  const totalItems = filteredProducts.length;
+  const totalPages = Math.ceil(totalItems / limit);
+  const currentPage = totalPages === 0 ? 1 : Math.min(page, totalPages);
+  const visibleProducts = useMemo(() => {
+    const start = (currentPage - 1) * limit;
+    return filteredProducts.slice(start, start + limit);
+  }, [currentPage, filteredProducts, limit]);
+
+  const handlePageChange = (nextPage: number) => {
+    setPage(nextPage);
   };
 
-  const handleLimitChange = (limit: number) => {
-    getData(1, limit); // Reset to page 1 when changing limit
+  const handleLimitChange = (nextLimit: number) => {
+    setLimit(nextLimit);
+    setPage(1);
+  };
+
+  const handleCategoryChange = (categoryId: number | null) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+
+    if (categoryId === null) {
+      nextSearchParams.delete("categoryId");
+    } else {
+      nextSearchParams.set("categoryId", String(categoryId));
+    }
+
+    setPage(1);
+    setSearchParams(nextSearchParams);
   };
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: TODO: useEventEffect in 19
@@ -61,8 +127,36 @@ function ProductList() {
           </div>
         ) : (
           <>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                aria-pressed={selectedCategoryId === null}
+                onClick={() => handleCategoryChange(null)}
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors ${
+                  selectedCategoryId === null
+                    ? "border-gray-900 bg-gray-900 text-white"
+                    : "border-gray-300 bg-white text-gray-700 hover:border-gray-500"
+                }`}>
+                All
+              </button>
+              {categories.map((category) => (
+                <button
+                  type="button"
+                  key={category.categoryId}
+                  aria-pressed={selectedCategoryId === category.categoryId}
+                  onClick={() => handleCategoryChange(category.categoryId)}
+                  className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors ${
+                    selectedCategoryId === category.categoryId
+                      ? "border-gray-900 bg-gray-900 text-white"
+                      : "border-gray-300 bg-white text-gray-700 hover:border-gray-500"
+                  }`}>
+                  {category.categoryName}
+                </button>
+              ))}
+            </div>
+
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-8">
-              {products.map((product) => (
+              {visibleProducts.map((product) => (
                 <div
                   key={product.id}
                   className="bg-white rounded-lg shadow-md flex flex-col h-full">
@@ -96,16 +190,22 @@ function ProductList() {
               ))}
             </div>
 
-            <Pagination
-              currentPage={pagination.page}
-              totalPages={pagination.totalPages}
-              totalItems={pagination.totalItems}
-              limit={pagination.limit}
-              hasNextPage={pagination.hasNextPage}
-              hasPreviousPage={pagination.hasPreviousPage}
-              onPageChange={handlePageChange}
-              onLimitChange={handleLimitChange}
-            />
+            {totalItems === 0 ? (
+              <div className="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-8 text-center text-gray-600">
+                No products found.
+              </div>
+            ) : (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                limit={limit}
+                hasNextPage={currentPage < totalPages}
+                hasPreviousPage={currentPage > 1}
+                onPageChange={handlePageChange}
+                onLimitChange={handleLimitChange}
+              />
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add API-backed category chips to the home catalog page
- load the small catalog with a high product limit and filter/paginate client-side by URL-backed `categoryId`
- add category/product response typing and ProductList coverage for URL initialization, All reset, null-category products, and category fetch failure
- record the storefront/domain decisions from the planning session

## Validation
- `pnpm biome check src/pages/ProductList.tsx src/pages/ProductList.test.tsx src/interfaces/category.ts src/interfaces/index.ts src/interfaces/productResponse.ts`
- `pnpm test -- ProductList.test.tsx`
- `pnpm run build`
- `git diff --check`

## Notes
- Full `pnpm run check` still reports unrelated pre-existing formatting issues in `ErrorBoundary.test.tsx`, `Product.test.tsx`, `Profile.test.tsx`, and `webauthn.test.ts`.
